### PR TITLE
call cb in swaggerGenerator to fix chaining to next gulp task

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,8 @@ function swaggerGenerator(options) {
                 .then(loadTemplateFiles)
                 .then(loadLanguageOptions)
                 .then(wrapHandleBarsContext)
-                .then(applyTemplates);
+                .then(applyTemplates)
+                .then(function () { cb(); });
         }
     });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,8 @@ function swaggerGenerator(options: swaggerGeneratorDef.ISwaggerGeneratorOptions)
                 .then(loadTemplateFiles)
                 .then(loadLanguageOptions)
                 .then(wrapHandleBarsContext)
-                .then(applyTemplates);
+                .then(applyTemplates)
+                .then(function() {cb();});
         }
     })
 }


### PR DESCRIPTION
My first pull request here on github and new to gulp as well. My gulp tasks were having trouble running in sequence with gulp-swagger-generator. Calling the passed in callback seems to clear it up. If this is not the correct way to fix this, I'd be happy to rework it.
