### PR TITLE
Multiple file typescript client generation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,14 +53,32 @@ function wrapHandleBarsContext(context) {
     return Promise.resolve(context);
 }
 function applyTemplates(context) {
+    var templates = [];
     if (context.options.singleFile) {
-        var singleFileTemplate = context.templates['SingleFile'];
-        gutil.log(JSON.stringify(Object.keys(context.templates)));
+        templates.push('SingleFile');
+    }
+    else {
+        templates.push('Definition');
+        if (context.options.templateOptions.generateInterface) {
+            templates.push('Interface');
+        }
+        if (context.options.templateOptions.arguments && context.options.templateOptions.arguments.asInterface) {
+            templates.push('ArgumentInterface');
+        }
+        templates.push('Client');
+        if (context.options.templateOptions.generateMock) {
+            templates.push('Mock');
+        }
+    }
+    for (var _i = 0, templates_1 = templates; _i < templates_1.length; _i++) {
+        var template = templates_1[_i];
+        gutil.log(template);
+        var fileName = context.options.singleFile ? context.options.clientName : template;
         var serviceClientFile = new gutil.File({
             cwd: "",
             base: "",
-            path: context.options.clientName + context.languageOptions.fileExtension,
-            contents: new Buffer(singleFileTemplate(context.handlebarsContext), 'utf8')
+            path: fileName + context.languageOptions.fileExtension,
+            contents: new Buffer(context.templates[template](context.handlebarsContext), 'utf8')
         });
         context.through.push(serviceClientFile);
     }

--- a/lib/templates/typescript/angular/ArgumentInterface.hbs
+++ b/lib/templates/typescript/angular/ArgumentInterface.hbs
@@ -1,9 +1,20 @@
-{{#api.operations}}
-    /*{{pascalCase verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}} operation arguments. */
-    export interface I{{pascalCaseOverwriteCasing verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}Args {
-    {{#args}}
-        /*{{description}}*/
-        {{camlCase name}}{{#if optional}}?{{/if}}: {{> Type}};
-    {{/args}}
-    }
-{{/api.operations}}
+{{#unless @root.isSingleFile }}
+{{#if @root.options.module }}
+module {{@root.options.module}} {
+{{/if}}
+    "use strict";
+{{/unless}}
+    {{#api.operations}}
+        /*{{pascalCase verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}} operation arguments. */
+        export interface I{{pascalCaseOverwriteCasing verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}Args {
+        {{#args}}
+            /*{{description}}*/
+            {{camlCase name}}{{#if optional}}?{{/if}}: {{> Type}};
+        {{/args}}
+        }
+    {{/api.operations}}
+{{#unless @root.isSingleFile }}
+{{#if @root.options.module }}
+}
+{{/if}}
+{{/unless}}

--- a/lib/templates/typescript/angular/Client.hbs
+++ b/lib/templates/typescript/angular/Client.hbs
@@ -1,27 +1,17 @@
-export class {{clientName}}{{#if options.generateInterface}} implements I{{clientName}}{{/if}} {
+export class {{clientName}}{{#if @root.options.generateInterface}} implements I{{clientName}}{{/if}} {
     private baseUri: string;
     private hostName: string;
     private scheme: string;
 
     /* @ngInject */
     constructor(
-        {{#options.inject}}
+        {{#if @root.options.inject}}
         private {{name}}: {{type}},
-        {{/options.inject}}
+        {{/if}}
         private $http: angular.IHttpService
     ) {
-        this.hostName = '{{#options.host.override}}{{.}}{{/options.host.override}}{{#unless options.host.override}}{{api.host}}{{/unless}}';
-        {{#options.host.set}}
-        if ({{.}}) {
-            this.hostName = {{.}};
-        }
-        {{/options.host.set}}
-        this.scheme = '{{#options.scheme.override}}{{.}}{{/options.scheme.override}}{{#unless options.scheme.override}}'http'{{/unless}}';
-        {{#options.scheme.set}}
-            if ({{.}}) {
-                this.scheme = {{.}};
-            }
-        {{/options.scheme.set}}
+        this.hostName = '{{#if @root.options.host}}{{@root.options.host}}{{else}}{{api.host}}{{/if}}';
+        this.scheme = '{{#if @root.options.scheme}}{{@root.options.scheme}}{{else}}http{{/if}}';
         this.baseUri = this.scheme + '://' + this.hostName {{#api.basePath}}+ '{{.}}'{{/api.basePath}};
     }
 

--- a/lib/templates/typescript/angular/Client.hbs
+++ b/lib/templates/typescript/angular/Client.hbs
@@ -1,98 +1,109 @@
-export class {{clientName}}{{#if @root.options.generateInterface}} implements I{{clientName}}{{/if}} {
-    private baseUri: string;
-    private hostName: string;
-    private scheme: string;
+{{#unless @root.isSingleFile }}
+{{#if @root.options.module }}
+module {{@root.options.module}} {
+{{/if}}
+    "use strict";
+{{/unless}}
+    export class {{clientName}}{{#if @root.options.generateInterface}} implements I{{clientName}}{{/if}} {
+        private baseUri: string;
+        private hostName: string;
+        private scheme: string;
 
-    /* @ngInject */
-    constructor(
-        {{#if @root.options.inject}}
-        private {{name}}: {{type}},
-        {{/if}}
-        private $http: angular.IHttpService
-    ) {
-        this.hostName = '{{#if @root.options.host}}{{@root.options.host}}{{else}}{{api.host}}{{/if}}';
-        this.scheme = '{{#if @root.options.scheme}}{{@root.options.scheme}}{{else}}http{{/if}}';
-        this.baseUri = this.scheme + '://' + this.hostName {{#api.basePath}}+ '{{.}}'{{/api.basePath}};
-    }
-
-{{#api.operations}}
-    /**
-    * {{description}}
-    {{#args}}
-    * @param { {{> Type}} } {{camlCase name}} {{description}}
-    {{/args}}
-    * @return { {{> Type successsResponse}} } {{successResponse.title}}
-    */
-    {{lowerCase verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}(
-    {{#if @root.options.arguments.asInterface}}
-        args: I{{pascalCaseOverwriteCasing verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}Args,
-    {{/if}}
-    {{#unless @root.options.arguments.asInterface}}
-        {{#args}}
-            {{camlCase name}}{{#if optional}}?{{/if}}: {{> Type}},
-        {{/args}}
-    {{/unless}}
-        canceller?: angular.IDeferred<any>
-    ) : angular.IHttpPromise<{{> Type successResponse}}> {
-
-        var uri = this.baseUri + {{#pathSegments}}{{#isParam}}{{#if @first}}'/' + {{/if}}{{#unless @first}}' + {{/unless}}String({{#if @root.options.arguments.asInterface}}args.{{/if}}{{camlCase name}}){{#unless @last}} + '/{{/unless}}{{/isParam}}{{#unless isParam}}{{#if @first}}'/{{/if}}{{name}}{{#unless @last}}/{{/unless}}{{#if @last}}'{{/if}}{{/unless}}{{/pathSegments}};
-
-        var httpRequestParams: any = {
-            method: '{{verb}}',
-            url: uri,
-            {{#isJsonResponse}}
-            json: true,
-            {{/isJsonResponse}}
-            {{#isBinaryResponse}}
-            responseType: 'arraybuffer',
-            {{/isBinaryResponse}}
-            {{#requestBody}}
-            data: {{#if @root.options.arguments.asInterface}}args.{{/if}}{{camlCase name}},
-            {{/requestBody}}
-            {{#if @root.options.defaultTimeout}}
-            timeout: {{@root.options.defaultTimeout}},
+        /* @ngInject */
+        constructor(
+            {{#if @root.options.inject}}
+            private {{name}}: {{type}},
             {{/if}}
-            params: {
-            {{#query}}
-                '{{name}}': {{#if @root.options.arguments.asInterface}}args.{{/if}}{{camlCase name}}{{#unless @last}},{{/unless}}
-            {{/query}}
-            },
-            headers: {
-            {{#headers}}
-                '{{name}}': {{#if @root.options.arguments.asInterface}}args.{{/if}}{{camlCase name}}{{#unless @last}},{{/unless}}
-            {{/headers}}
-            }
-        };
-
-    {{#isFormDataRequest}}
-        var formData = new FormData();
-    {{#formData}}
-        {{#getType this}}
-        {{#if isFile}}
-        formData.append('{{../name}}', new Blob([ {{#if @root.options.arguments.asInterface}}args.{{/if}}{{camlCase ../name }} ], {type: 'application/octet-stream'}));
-        {{/if}}
-        {{#unless isFile}}
-        formData.append('{{../name}}', {{#if @root.options.arguments.asInterface}}args.{{/if}}{{camlCase ../name}});
-        {{/unless}}
-        {{/getType}}
-    {{/formData}}
-        httpRequestParams.data = formData;
-        httpRequestParams.transformRequest = data => data;
-        httpRequestParams.headers['Content-Type'] = undefined;
-    {{/isFormDataRequest}}
-
-        if (canceller){
-            httpRequestParams.timeout = canceller.promise;
+            private $http: angular.IHttpService
+        ) {
+            this.hostName = '{{#if @root.options.host}}{{@root.options.host}}{{else}}{{api.host}}{{/if}}';
+            this.scheme = '{{#if @root.options.scheme}}{{@root.options.scheme}}{{else}}http{{/if}}';
+            this.baseUri = this.scheme + '://' + this.hostName {{#api.basePath}}+ '{{.}}'{{/api.basePath}};
         }
 
-    {{#mapLookup @root.options.security security}}
-        {{#configure}}
-        httpRequestParams = this.{{.}}(httpRequestParams);
-        {{/configure}}
-    {{/mapLookup}}
+    {{#api.operations}}
+        /**
+        * {{description}}
+        {{#args}}
+        * @param { {{> Type}} } {{camlCase name}} {{description}}
+        {{/args}}
+        * @return { {{> Type successsResponse}} } {{successResponse.title}}
+        */
+        {{lowerCase verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}(
+        {{#if @root.options.arguments.asInterface}}
+            args: I{{pascalCaseOverwriteCasing verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}Args,
+        {{/if}}
+        {{#unless @root.options.arguments.asInterface}}
+            {{#args}}
+                {{camlCase name}}{{#if optional}}?{{/if}}: {{> Type}},
+            {{/args}}
+        {{/unless}}
+            canceller?: angular.IDeferred<any>
+        ) : angular.IHttpPromise<{{> Type successResponse}}> {
 
-        return this.$http(httpRequestParams);
+            var uri = this.baseUri + {{#pathSegments}}{{#isParam}}{{#if @first}}'/' + {{/if}}{{#unless @first}}' + {{/unless}}String({{#if @root.options.arguments.asInterface}}args.{{/if}}{{camlCase name}}){{#unless @last}} + '/{{/unless}}{{/isParam}}{{#unless isParam}}{{#if @first}}'/{{/if}}{{name}}{{#unless @last}}/{{/unless}}{{#if @last}}'{{/if}}{{/unless}}{{/pathSegments}};
+
+            var httpRequestParams: any = {
+                method: '{{verb}}',
+                url: uri,
+                {{#isJsonResponse}}
+                json: true,
+                {{/isJsonResponse}}
+                {{#isBinaryResponse}}
+                responseType: 'arraybuffer',
+                {{/isBinaryResponse}}
+                {{#requestBody}}
+                data: {{#if @root.options.arguments.asInterface}}args.{{/if}}{{camlCase name}},
+                {{/requestBody}}
+                {{#if @root.options.defaultTimeout}}
+                timeout: {{@root.options.defaultTimeout}},
+                {{/if}}
+                params: {
+                {{#query}}
+                    '{{name}}': {{#if @root.options.arguments.asInterface}}args.{{/if}}{{camlCase name}}{{#unless @last}},{{/unless}}
+                {{/query}}
+                },
+                headers: {
+                {{#headers}}
+                    '{{name}}': {{#if @root.options.arguments.asInterface}}args.{{/if}}{{camlCase name}}{{#unless @last}},{{/unless}}
+                {{/headers}}
+                }
+            };
+
+        {{#isFormDataRequest}}
+            var formData = new FormData();
+        {{#formData}}
+            {{#getType this}}
+            {{#if isFile}}
+            formData.append('{{../name}}', new Blob([ {{#if @root.options.arguments.asInterface}}args.{{/if}}{{camlCase ../name }} ], {type: 'application/octet-stream'}));
+            {{/if}}
+            {{#unless isFile}}
+            formData.append('{{../name}}', {{#if @root.options.arguments.asInterface}}args.{{/if}}{{camlCase ../name}});
+            {{/unless}}
+            {{/getType}}
+        {{/formData}}
+            httpRequestParams.data = formData;
+            httpRequestParams.transformRequest = data => data;
+            httpRequestParams.headers['Content-Type'] = undefined;
+        {{/isFormDataRequest}}
+
+            if (canceller){
+                httpRequestParams.timeout = canceller.promise;
+            }
+
+        {{#mapLookup @root.options.security security}}
+            {{#configure}}
+            httpRequestParams = this.{{.}}(httpRequestParams);
+            {{/configure}}
+        {{/mapLookup}}
+
+            return this.$http(httpRequestParams);
+        }
+
+    {{/api.operations}}
     }
-
-{{/api.operations}}
+{{#unless @root.isSingleFile }}
+{{#if @root.options.module }}
 }
+{{/if}}
+{{/unless}}

--- a/lib/templates/typescript/angular/Definition.hbs
+++ b/lib/templates/typescript/angular/Definition.hbs
@@ -1,10 +1,20 @@
-
-/*{{pascalCase rawName}}*/
-export interface {{pascalCase rawName}} {{#ancestor}}extends {{pascalCase rawName}}{{/ancestor}} {
-
-{{#properties}}
-    /*{{description}}*/
-    {{name}} : {{> Type }};
-
-{{/properties}}
+{{#unless @root.isSingleFile }}
+{{#if @root.options.module }}
+module {{@root.options.module}} {
+{{/if}}
+    "use strict";
+{{/unless}}
+{{#api.definitions}}
+    /*{{pascalCase rawName}}*/
+    export interface {{pascalCase rawName}} {{#ancestor}}extends {{pascalCase rawName}}{{/ancestor}} {
+    {{#properties}}
+        /*{{description}}*/
+        {{name}} : {{> Type }};
+    {{/properties}}
+    }
+{{/api.definitions}}
+{{#unless @root.isSingleFile }}
+{{#if @root.options.module }}
 }
+{{/if}}
+{{/unless}}

--- a/lib/templates/typescript/angular/Interface.hbs
+++ b/lib/templates/typescript/angular/Interface.hbs
@@ -1,24 +1,35 @@
-export interface I{{clientName}}  {
-
-{{#api.operations}}
-    /**
-    * {{description}}
-    {{#args}}
-        * @param { {{> Type}} } {{camlCase name}} {{description}}
-    {{/args}}
-    * @return { {{> Type successsResponse}} } {{successResponse.title}}
-    */
-    {{lowerCase verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}(
-    {{#if @root.options.arguments.asInterface}}
-        args: I{{pascalCaseOverwriteCasing verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}Args,
-    {{/if}}
-{{#unless @root.options.arguments.asInterface}}
-    {{#args}}
-        {{camlCase name}}{{#if optional}}?{{/if}}: {{> Type}},
-    {{/args}}
+{{#unless @root.isSingleFile }}
+{{#if @root.options.module }}
+module {{@root.options.module}} {
+{{/if}}
+    "use strict";
 {{/unless}}
-        canceller?: angular.IDeferred<any>
-        ) : angular.IHttpPromise<{{> Type successResponse}}>;
+    export interface I{{clientName}}  {
 
-{{/api.operations}}
+    {{#api.operations}}
+        /**
+        * {{description}}
+        {{#args}}
+            * @param { {{> Type}} } {{camlCase name}} {{description}}
+        {{/args}}
+        * @return { {{> Type successsResponse}} } {{successResponse.title}}
+        */
+        {{lowerCase verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}(
+        {{#if @root.options.arguments.asInterface}}
+            args: I{{pascalCaseOverwriteCasing verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}Args,
+        {{/if}}
+    {{#unless @root.options.arguments.asInterface}}
+        {{#args}}
+            {{camlCase name}}{{#if optional}}?{{/if}}: {{> Type}},
+        {{/args}}
+    {{/unless}}
+            canceller?: angular.IDeferred<any>
+            ) : angular.IHttpPromise<{{> Type successResponse}}>;
+
+    {{/api.operations}}
+    }
+{{#unless @root.isSingleFile }}
+{{#if @root.options.module }}
 }
+{{/if}}
+{{/unless}}

--- a/lib/templates/typescript/angular/Mock.hbs
+++ b/lib/templates/typescript/angular/Mock.hbs
@@ -1,62 +1,73 @@
-export class {{clientName}}Mock{{#if options.generateInterface}} implements I{{clientName}}{{/if}} {
-
-    /* @ngInject */
-    constructor(
-        private $q: angular.IQService,
-        private $timeout: any
-    ) {
-
-    }
-
-{{#api.operations}}
-    /**
-    * {{description}}
-    {{#args}}
-        * @param { {{> Type}} } {{camlCase name}} {{description}}
-    {{/args}}
-    * @return { {{> Type successsResponse}} } {{successResponse.title}}
-    */
-    {{lowerCase verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}(
-    {{#if @root.options.arguments.asInterface}}
-        args: I{{pascalCaseOverwriteCasing verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}Args,
-    {{/if}}
-{{#unless @root.options.arguments.asInterface}}
-    {{#args}}
-        {{camlCase name}}{{#if optional}}?{{/if}}: {{> Type}},
-    {{/args}}
+{{#unless @root.isSingleFile }}
+{{#if @root.options.module }}
+module {{@root.options.module}} {
+{{/if}}
+    "use strict";
 {{/unless}}
-        canceller?: angular.IDeferred<any>
-        ) : angular.IHttpPromise<{{> Type successResponse}}> {
+    export class {{clientName}}Mock{{#if options.generateInterface}} implements I{{clientName}}{{/if}} {
 
-            var data: {{> Type successResponse}} = null;
+        /* @ngInject */
+        constructor(
+            private $q: angular.IQService,
+            private $timeout: any
+        ) {
 
-            {{#isJsonResponse}}{{#mapLookup successSamples 'application/json'}}
-            data = <any>{{json .}};
-            {{/mapLookup}}{{/isJsonResponse}}
-        {{#unless @root.options.mock.delay}}
-            return <any>this.$q.when<angular.IHttpPromiseCallbackArg<{{> Type successResponse}}>>({
-                data: data,
-                status: 200,
-            });
-        {{/unless}}
-        {{#if @root.options.mock.delay}}
-            return <any>this.delayResponse<angular.IHttpPromiseCallbackArg<{{> Type successResponse}}>>({
-            data: data,
-            status: 200,
-            });
-        {{/if}}
         }
 
-{{/api.operations}}
-{{#if options.mock.delay}}
-    private delayResponse<T>(data: T): angular.IHttpPromise<T>{
-        var deferral = this.$q.defer<T>();
+    {{#api.operations}}
+        /**
+        * {{description}}
+        {{#args}}
+            * @param { {{> Type}} } {{camlCase name}} {{description}}
+        {{/args}}
+        * @return { {{> Type successsResponse}} } {{successResponse.title}}
+        */
+        {{lowerCase verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}(
+        {{#if @root.options.arguments.asInterface}}
+            args: I{{pascalCaseOverwriteCasing verb}}{{#pathSegments}}{{#isParam}}By{{/isParam}}{{pascalCase name}}{{/pathSegments}}Args,
+        {{/if}}
+    {{#unless @root.options.arguments.asInterface}}
+        {{#args}}
+            {{camlCase name}}{{#if optional}}?{{/if}}: {{> Type}},
+        {{/args}}
+    {{/unless}}
+            canceller?: angular.IDeferred<any>
+            ) : angular.IHttpPromise<{{> Type successResponse}}> {
 
-        this.$timeout(()=>{
-            deferral.resolve(data);
-        }, {{options.mock.delay}});
+                var data: {{> Type successResponse}} = null;
 
-        return <any>deferral.promise;
+                {{#isJsonResponse}}{{#mapLookup successSamples 'application/json'}}
+                data = <any>{{json .}};
+                {{/mapLookup}}{{/isJsonResponse}}
+            {{#unless @root.options.mock.delay}}
+                return <any>this.$q.when<angular.IHttpPromiseCallbackArg<{{> Type successResponse}}>>({
+                    data: data,
+                    status: 200,
+                });
+            {{/unless}}
+            {{#if @root.options.mock.delay}}
+                return <any>this.delayResponse<angular.IHttpPromiseCallbackArg<{{> Type successResponse}}>>({
+                data: data,
+                status: 200,
+                });
+            {{/if}}
+            }
+
+    {{/api.operations}}
+    {{#if options.mock.delay}}
+        private delayResponse<T>(data: T): angular.IHttpPromise<T>{
+            var deferral = this.$q.defer<T>();
+
+            this.$timeout(()=>{
+                deferral.resolve(data);
+            }, {{options.mock.delay}});
+
+            return <any>deferral.promise;
+        }
+    {{/if}}
     }
-{{/if}}
+{{#unless @root.isSingleFile }}
+{{#if @root.options.module }}
 }
+{{/if}}
+{{/unless}}

--- a/lib/templates/typescript/angular/SingleFile.hbs
+++ b/lib/templates/typescript/angular/SingleFile.hbs
@@ -2,22 +2,20 @@
 module {{options.module}} {
 {{/if}}
     "use strict";
-{{#api.definitions}}
-    {{> Definition }}
-{{/api.definitions}}
-
+{{> Definition }}
 {{#if options.generateInterface}}
-    {{> Interface }}
-{{/if}}
 
+{{> Interface }}
+{{/if}}
 {{#if options.arguments.asInterface}}
-    {{> ArgumentInterface }}
+
+{{> ArgumentInterface }}
 {{/if}}
 
-    {{> Client }}
-
+{{> Client }}
 {{#if options.generateMock}}
-    {{> Mock }}
+
+{{> Mock }}
 {{/if}}
 {{#if options.module}}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,19 +73,33 @@ function wrapHandleBarsContext(context: swaggerGeneratorDef.Context): Promise<sw
 }
 
 function applyTemplates(context: swaggerGeneratorDef.Context): Promise<swaggerGeneratorDef.Context> {
-
-    if (context.options.singleFile) {
-        let singleFileTemplate = context.templates['SingleFile'];
-        gutil.log(JSON.stringify(Object.keys(context.templates)));
+    let templates: string[] = [];
+    if(context.options.singleFile) {
+        templates.push('SingleFile');
+    } else {
+        templates.push('Definition');
+        if(context.options.templateOptions.generateInterface) {
+            templates.push('Interface');
+        }
+        if(context.options.templateOptions.arguments && context.options.templateOptions.arguments.asInterface) {
+            templates.push('ArgumentInterface');
+        }
+        templates.push('Client');
+        if(context.options.templateOptions.generateMock) {
+            templates.push('Mock');
+        }
+    }
+    for(let template of templates) {
+        gutil.log(template);
+        let fileName = context.options.singleFile ? context.options.clientName : template;
         var serviceClientFile = new gutil.File({
             cwd: "",
             base: "",
-            path: context.options.clientName + context.languageOptions.fileExtension,
-            contents: new Buffer(singleFileTemplate(context.handlebarsContext), 'utf8')
+            path: fileName + context.languageOptions.fileExtension,
+            contents: new Buffer(context.templates[template](context.handlebarsContext), 'utf8')
         });
         context.through.push(serviceClientFile);
     }
-
     return Promise.resolve(context);
 }
 


### PR DESCRIPTION
This started as a fix for a problem I ran into with the scheme choice in the generated typescript client. I then went on to try enabling the isSingleFile=false. This is working ok in the project I'm trying this generator in, but I'm not that familiar with handlebars. The strategy I used was just toggling module information for the individual files vs. the single file templates. I then choose which templates to run by mimicking the option logic from the SingleFile template in the applyTemplates method. I employ a very naive file naming strategy depending on single vs. multiple file. When multiple file, I just name the output the template name. I would appreciate any suggestions for reworking this to make it more general.
