### PR TITLE
Dereference swagger spec instead of parsing it

### DIFF
--- a/customTypings/swagger-parser/swagger-parser.d.ts
+++ b/customTypings/swagger-parser/swagger-parser.d.ts
@@ -163,5 +163,8 @@ declare module "swagger-parser" {
 
     export function parse(file: string, options: IOptions, callback: (err: Error, api: IApi, metadata: any) => void): void;
     export function parse(file: string, callback: (err: Error, api: IApi, metadata: IMetadata) => void): void;
+
+    export function dereference(file: string, options: IOptions, callback: (err: Error, api: IApi, metadata: any) => void): void;
+    export function dereference(file: string, callback: (err: Error, api: IApi, metadata: IMetadata) => void): void;
 }
 

--- a/lib/swaggerGenerator.d.ts
+++ b/lib/swaggerGenerator.d.ts
@@ -1,0 +1,26 @@
+/// <reference path="../typings.d.ts" />
+import parse = require('./parse');
+declare module swaggerGenerator {
+    interface ISwaggerGeneratorOptions {
+        clientName?: string;
+        singleFile?: boolean;
+        template: string;
+        templatePath?: string;
+        templateOptions: any;
+        handlerbarsExtensions?: any;
+        renameDefinitions?: {
+            [from: string]: string;
+        };
+    }
+    interface Context {
+        options: ISwaggerGeneratorOptions;
+        api?: parse.IParsedSwagger;
+        templates?: {
+            [name: string]: HandlebarsTemplateDelegate;
+        };
+        handlebarsContext?: any;
+        through: any;
+        languageOptions?: any;
+    }
+}
+export = swaggerGenerator;

--- a/lib/swaggerGenerator.js
+++ b/lib/swaggerGenerator.js
@@ -1,0 +1,1 @@
+"use strict";

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -12,7 +12,7 @@ export interface IParsedSwagger {
 
 export function parse(file: string): Promise<IParsedSwagger> {
     var deferral = Promise.defer<IParsedSwagger>();
-    parser.parse(file,{
+    parser.dereference(file,{
         parseYaml : true,
         dereference$Refs : false,
         dereferenceInternal$Refs :  false,


### PR DESCRIPTION
Hello,

consider the following example API:

``` yaml
swagger: '2.0'
info:
  title: Test
  description: Test
  version: "0.0.1"
paths:
  /test:
    get:
      parameters:
        - $ref: "#/parameters/foobar"
      responses:
        default:
          description: Successful response
          schema:
            title: Bar
            type: string
parameters:
  foobar:
    name: foo
    in: query
    description: Foo
    type: string
    required: true
```

The important part is how the parameter is referenced.
This is currently not supported by your plugin (it will never be dereferenced and crash in the template).
You are currently using swagger-parser, but you use the method parse. Instead you could call the method dereference (which will internally call parse), which will fix this issue.
