### PR TITLE
Use last file from history

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ function swaggerGenerator(options) {
             throw diagnostics.newPluginError('A description file is required');
         }
         if (file.isBuffer()) {
-            nodeSwaggerGenerator.generateFromJsonOrYaml(file.history[0], options, new GulpSink(through2Context))
+            nodeSwaggerGenerator.generateFromJsonOrYaml(file.history.pop(), options, new GulpSink(through2Context))
                 .catch(function (err) { return cb(err); })
                 .then(function () { return cb(); });
         }


### PR DESCRIPTION
It is nice due to can be chained via gulp like that

``` js
import gulp from 'gulp';
import download from 'gulp-download';
import rename from 'gulp-rename';
import generator from 'gulp-swagger-generator-vk';

gulp.task('api:generate', () => {
    return download('url')
        .pipe(rename(`SomeApi.json`))
        .pipe(gulp.dest('./dist/'))
        .pipe(generator({...}))
        .pipe(rename(`SomeApi.ts`))
        .pipe(gulp.dest('./dist'));
});
```
